### PR TITLE
New application states for head closure sequence

### DIFF
--- a/devnet-source/genesis-shelley.json
+++ b/devnet-source/genesis-shelley.json
@@ -4,7 +4,7 @@
         "poolDeposit": 0,
         "protocolVersion": {
             "minor": 0,
-            "major": 0
+            "major": 6
         },
         "minUTxOValue": 0,
         "decentralisationParam": 1,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:latest
+    image: inputoutput/cardano-node:1.34.1
     volumes:
       - ./devnet:/data
     environment:
@@ -20,7 +20,7 @@ services:
       ]
 
   hydra-node-alice:
-    image: ghcr.io/input-output-hk/hydra-node@sha256:6ff08464a426fe2e6e4c7b4c091cc61cae10efa28276adf0914f2d33bd45742a
+    image: ghcr.io/input-output-hk/hydra-node:0.6.0
     volumes:
       - ./keys:/keys:ro
       - ./devnet/credentials:/credentials:ro
@@ -49,7 +49,7 @@ services:
     restart: always
 
   hydra-node-bob:
-    image: ghcr.io/input-output-hk/hydra-node@sha256:6ff08464a426fe2e6e4c7b4c091cc61cae10efa28276adf0914f2d33bd45742a
+    image: ghcr.io/input-output-hk/hydra-node:0.6.0
     volumes:
       - ./keys:/keys:ro
       - ./devnet/credentials:/credentials:ro

--- a/flake.nix
+++ b/flake.nix
@@ -57,19 +57,15 @@
         ];
 
         flake = pkgs.hydraDemoProject.flake { };
+        exe-component-name = "hydra-demo:exe:hydra-rps-game";
 
       in
-      {
-        flake = flake // {
-          defaultPackage = flake.packages."hydra-demo:exe:hydra-rps-game";
-        };
-        packages = self.flake.${system}.packages;
-        checks = self.flake.${system}.checks;
+      flake // {
+        defaultPackage = flake.packages.${exe-component-name};
+        defaultApp = flake.apps.${exe-component-name};
         check = pkgs.runCommand "combined-test"
           {
-            nativeBuildInputs = builtins.attrValues self.checks.${system};
+            nativeBuildInputs = builtins.attrValues flake.checks;
           } "touch $out";
-        apps = self.flake.${system}.apps;
-        devShell = self.flake.${system}.devShell;
       });
 }

--- a/spin-up-devnet-from-scratch
+++ b/spin-up-devnet-from-scratch
@@ -1,0 +1,16 @@
+#!/bin/sh -e
+
+cd "$(dirname "$(realpath "$0")")"
+
+docker-compose down
+./reset-devnet.sh
+docker-compose up -d
+echo -n 'Waiting for the node socket ..'
+while ! [ -S devnet/ipc/node.socket ]
+do
+  echo -n .
+  sleep 0.1
+done
+echo '. done'
+sudo chown -Rv $(id -u):$(id -g) devnet/ipc
+docker-compose exec cardano-node bash -c 'cd /data; . ./init.sh'

--- a/spin-up-devnet-from-scratch
+++ b/spin-up-devnet-from-scratch
@@ -12,5 +12,4 @@ do
   sleep 0.1
 done
 echo '. done'
-sudo chown -Rv $(id -u):$(id -g) devnet/ipc
-docker-compose exec cardano-node bash -c 'cd /data; . ./init.sh'
+docker-compose exec -T -w /data cardano-node bash init.sh


### PR DESCRIPTION
`playTheGame` => (on `HeadIsClosed`) `waitForFanout` => (on `ReadyToFanout`) `waitForFinalization` => (on `HeadIsFinalized`) `openTheHead`

During `playTheGame` we allow `CloseHead` user input.

During `waitForFanout` we do not allow any input - probably, `Contest` can happen here, but it seems contestation is performed without user intervention (https://github.com/input-output-hk/hydra-poc/issues/192). Needs clarification.

During waitForFinalization we allow only `IssueFanout` input.